### PR TITLE
Added logging service and logs to migrate-images command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.4.2] - 2026-04-13
+### Added
+- Logging service to allow creation of logs in `Storage/logs/walsgit-discussion-cards/`.
+- The command `php flarum discussion-cards:migrate-images` will now generate more detailed logs in migration-YYYY-mm-dd.log files when executed.
+### Changed
+- Better checks & validation for the command `php flarum discussion-cards:migrate-images` (do folders exists and have the right permissions, and cleanup shouldn't run if there's any file migration or DB error)
+### Fixed
+- Some typos.
+
 ## [1.4.1] - 2026-04-08
 ### Fixed
 - DB index creation wouldn't work on Flarum DBs with table prefixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@
 - Image stub (changed it for a more neutral one with the Flarum logo)
 - Migrations (with new settings keys and added new tag settings)
 - Switched read/unread discussions' filter (now read are grayscaled and unread are in full colors)
-- Reamde.md, License.md, namespace...
+- Readme.md, License.md, namespace...
 - Removed Russian translation
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.4.1] - 2026-04-08
 ### Fixed
-- DB index creation would work on Flarum DBs with table prefixes.
+- DB index creation wouldn't work on Flarum DBs with table prefixes.
 
 ## [1.4.0] - 2026-04-07
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "flarum-extension": {
-            "title": "Flarum Discussion Сards",
+            "title": "Flarum Discussion Cards",
             "category": "feature",
             "icon": {
                 "name": "fas fa-border-all",

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -155,6 +155,7 @@ walsgit_discussion_cards:
       imageMigrationServiceCleanupSuccess: "️✅ Cleanup: found and deleted {filename}"
       imageMigrationServiceUnknownError: "Unknown error"
       imageMigrationServiceCleanupFail: "❌ Cleanup failed! {filename} found but couldn't be deleted : {error}"
+      imageMigrationServiceNoCleanup: "⏭️ Due to {failedMigrations} failed migrations, cleanup was skipped"
       purgeImagesAlreadyRunning: "Purge Images is already running."
       purgeImagesDirectoryNotFound: "Directory {directory} not found."
       purgeImagesStart: "➡ Purging discussion cards images..."

--- a/locale/fr.yml
+++ b/locale/fr.yml
@@ -155,6 +155,7 @@ walsgit_discussion_cards:
       imageMigrationServiceCleanupSuccess: "️✅ Nettoyage : {filename} a été trouvé et supprimé"
       imageMigrationServiceUnknownError: "Erreur inconnue"
       imageMigrationServiceCleanupFail: "❌ Nettoyage échoué ! {filename} a été trouvé mais n'a pas pu être supprimé : {error}"
+      imageMigrationServiceNoCleanup: "⏭️ En raison de {failedMigrations} migrations échouées, le nettoyage a été ignoré"
       purgeImagesAlreadyRunning: "Purge Images tourne déjà."
       purgeImagesDirectoryNotFound: "Le dossier {directory} n'a pas été trouvé."
       purgeImagesStart: "➡ Purge des images des cartes de discussions..."

--- a/src/Image/CardImageResolver.php
+++ b/src/Image/CardImageResolver.php
@@ -216,7 +216,7 @@ class CardImageResolver
      */
     protected function getOptimizedCardImage(Discussion $discussion, string $imageUrl): string
     {
-        // If this is already one of the default images (global or tag) we uploaded (no need to reoptimize)
+        // If this is already one of the default images (global or tag) we uploaded (no need to re-optimize)
         if (Str::endsWith($imageUrl, 'default-card-image.webp')) {
             return $imageUrl;
         }
@@ -226,7 +226,7 @@ class CardImageResolver
             @mkdir($assetsPath, 0775, true);
         }
 
-        // 3rd party Blog Extention Support (returns filename or null)
+        // 3rd party Blog Extension Support (returns filename or null)
         $baseUrl = rtrim((string) $this->config->url(), '/');
         $optimizedBlog = $this->imageService->optimizeBlogDefaultImage($imageUrl, $baseUrl);
         if ($optimizedBlog) {

--- a/src/Services/LoggingService.php
+++ b/src/Services/LoggingService.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of walsgit/discussion-cards
+ *
+ *  Copyright (c) 2026 Wa!id.
+ *
+ *  For detailed copyright and license information, please view the
+ *  LICENSE file that was distributed with this source code.
+ */
+
+namespace Walsgit\Discussion\Cards\Services;
+
+use Flarum\Foundation\Paths;
+
+class LoggingService
+{
+    protected Paths $paths;
+    protected string $logDirectory;
+    protected string $prefix;
+
+    public function __construct(Paths $paths, string $prefix = 'general')
+    {
+        $this->paths = $paths;
+        $this->prefix = $prefix;
+
+        // Create log directory
+        $this->logDirectory = $this->paths->base . '/storage/logs/walsgit-discussion-cards';
+        if (!is_dir($this->logDirectory)) {
+            @mkdir($this->logDirectory, 0775, true);
+        }
+    }
+
+    /**
+     * Log a message with the specified level
+     */
+    public function log(string $message, string $level = 'INFO'): void
+    {
+        $timestamp = date('Y-m-d H:i:s');
+        $logMessage = "[{$timestamp}] [{$level}] {$message}" . PHP_EOL;
+
+        // Daily log file naming
+        $date = date('Y-m-d');
+        $logFile = "{$this->logDirectory}/{$this->prefix}-{$date}.log";
+
+        // Write to log file
+        file_put_contents($logFile, $logMessage, FILE_APPEND | LOCK_EX);
+    }
+
+    /**
+     * Log an info message
+     */
+    public function info(string $message): void
+    {
+        $this->log($message, 'INFO');
+    }
+
+    /**
+     * Log a warning message
+     */
+    public function warning(string $message): void
+    {
+        $this->log($message, 'WARNING');
+    }
+
+    /**
+     * Log an error message
+     */
+    public function error(string $message): void
+    {
+        $this->log($message, 'ERROR');
+    }
+
+    /**
+     * Log a debug message
+     */
+    public function debug(string $message): void
+    {
+        $this->log($message, 'DEBUG');
+    }
+
+    /**
+     * Get the current log file path for today
+     */
+    public function getCurrentLogFilePath(): string
+    {
+        $date = date('Y-m-d');
+        return "{$this->logDirectory}/{$this->prefix}-{$date}.log";
+    }
+}

--- a/src/Services/Migration/ImageMigrationService.php
+++ b/src/Services/Migration/ImageMigrationService.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of walsgit/discussion-cards
  *
- *  Copyright (c) 2025 Wa!id.
+ *  Copyright (c) 2026 Wa!id.
  *
  *  For detailed copyright and license information, please view the
  *  LICENSE file that was distributed with this source code.
@@ -14,6 +14,7 @@ namespace Walsgit\Discussion\Cards\Services\Migration;
 use Flarum\Foundation\Paths;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Walsgit\Discussion\Cards\Services\ImageProcessingService;
+use Walsgit\Discussion\Cards\Services\LoggingService;
 use Flarum\Tags\Tag;
 use Illuminate\Database\Connection;
 use Flarum\Locale\Translator;
@@ -25,6 +26,7 @@ class ImageMigrationService
     protected ImageProcessingService $imageService;
     protected Connection $db;
     protected $translator;
+    protected LoggingService $logger;
 
     public function __construct(
         Paths $paths,
@@ -38,11 +40,14 @@ class ImageMigrationService
         $this->imageService = $imageService;
         $this->db = $db;
         $this->translator = $translator;
+
+        // Initialize logger with 'migration' prefix
+        $this->logger = new LoggingService($paths, 'migration');
     }
 
     /**
      * Version 1.4.0 changes how and where default card images are processed and stored;
-     * This script will check the DB for the already set disucsion cards default image paths
+     * This script will check the DB for the already set discussion cards default image paths
      * and process (smaller webp file with new filenames) and migrate them to new location
      * then delete all old remaining discussion cards images still in /public/assets/ (using the old naming templates)
      */
@@ -52,18 +57,24 @@ class ImageMigrationService
         $assetsDir = $public . DIRECTORY_SEPARATOR . 'assets';
         $migratedCount = 0;
 
+        // Log start of migration
+        $this->logger->info("Starting image migration process");
+
         /*
         |--------------------------------------------------------------------------
         | 1) GENERAL DEFAULT IMAGE MIGRATION (only if a pre v1.4 filename is found in DB)
         |--------------------------------------------------------------------------
         */
         echo $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceStep1') . "\n";
+        $this->logger->info("Processing general default image migration");
 
-        $oldGeneralFilename = $this->settings->get('walsgit_discussion_cards_default_image_path'); 
+        $oldGeneralFilename = $this->settings->get('walsgit_discussion_cards_default_image_path');
+        $this->logger->info("Found general default image in settings: " . ($oldGeneralFilename ?: 'None'));
 
         // Old file was in /assets/card-image-{hash}.png
         if ($oldGeneralFilename && preg_match('#^card-image-[a-z0-9]+\.png$#i', $oldGeneralFilename)) {
             $oldPath = $assetsDir . DIRECTORY_SEPARATOR . $oldGeneralFilename;
+            $this->logger->info("Checking if old general image exists at: {$oldPath}");
 
             if (is_file($oldPath)) {
                 $targetDir = $public . '/assets/extensions/walsgit-discussion-cards';
@@ -71,6 +82,7 @@ class ImageMigrationService
 
                 $targetFilename = 'default-card-image.webp';
                 $targetPath = $targetDir . DIRECTORY_SEPARATOR . $targetFilename;
+                $this->logger->info("Processing general image: {$oldPath} -> {$targetPath}");
 
                 try {
                     $this->imageService->processImage($oldPath, $targetPath);
@@ -80,10 +92,15 @@ class ImageMigrationService
                     );
 
                     echo $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceGeneralImageSuccess', ['oldfilename' => $oldGeneralFilename, 'newfilepath' => $targetPath]) . "\n";
+                    $this->logger->info("Successfully migrated general default image: {$oldGeneralFilename} -> {$targetFilename}");
+                    $this->logger->info("Successfully set {$targetFilename} as the new general default image in the settings (DB)");
                     $migratedCount++;
                 } catch (\Throwable $e) {
                     echo $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceGeneralImageFail', ['filename' => $oldGeneralFilename]) . $e->getMessage() . "\n";
+                    $this->logger->error("Failed to migrate general default image from {$oldGeneralFilename} to {$targetFilename} and/or to set {$targetFilename} as the new general default image in the settings (DB), Error: " . $e->getMessage());
                 }
+            } else {
+                $this->logger->warning("Old general default image file not found: {$oldPath}");
             }
         }
 
@@ -93,9 +110,14 @@ class ImageMigrationService
         |--------------------------------------------------------------------------
         */
         echo $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceStep2') . "\n";
+        $this->logger->info("Processing tag default images migration");
 
-        foreach (Tag::all() as $tag) {
+        $tags = Tag::all();
+        $this->logger->info("Found " . $tags->count() . " tags to process");
+
+        foreach ($tags as $tag) {
             $oldTagFilename = $tag->walsgit_discussion_cards_tag_default_image;
+            $this->logger->info("Processing tag ID {$tag->id}: " . ($oldTagFilename ?: 'no default image'));
 
             if (! $oldTagFilename) {
                 continue;
@@ -103,10 +125,12 @@ class ImageMigrationService
 
             // Old files were in /assets/tag-{id}-card-image-{hash}.png
             if (! preg_match('#^tag-' . $tag->id . '-card-image-[a-z0-9]+\.png$#i', $oldTagFilename)) {
+                $this->logger->debug("Skipping tag {$tag->id}, found filename {$oldTagFilename} doesn't match old pattern");
                 continue;
             }
 
             $oldPath = $assetsDir . DIRECTORY_SEPARATOR . $oldTagFilename;
+            $this->logger->info("Checking if old tag default image exists at: {$oldPath}");
 
             if (is_file($oldPath)) {
                 $targetDir = $public . '/assets/extensions/walsgit-discussion-cards/tags';
@@ -114,6 +138,7 @@ class ImageMigrationService
 
                 $targetFilename = "tag-{$tag->id}-default-card-image.webp";
                 $targetPath = $targetDir . DIRECTORY_SEPARATOR . $targetFilename;
+                $this->logger->info("Processing tag image: {$oldPath} -> {$targetPath}...");
 
                 try {
                     $this->imageService->processImage($oldPath, $targetPath);
@@ -122,10 +147,15 @@ class ImageMigrationService
                     $tag->save();
 
                     echo $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceTagImageSuccess', ['oldfilename' => $oldTagFilename, 'tagid' => $tag->id, 'newfilepath' => $targetPath]) . "\n";
+                    $this->logger->info("Successfully migrated tag {$tag->id} default image: {$oldTagFilename} -> {$targetFilename}");
+                    $this->logger->info("Successfully set {$targetFilename} as the new tag {$tag->id} default image in the tag settings (DB)");
                     $migratedCount++;
                 } catch (\Throwable $e) {
                     echo $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceTagImageFail', ['filename' => $oldTagFilename, 'tagid' => $tag->id]) . $e->getMessage() . "\n";
+                    $this->logger->error("Failed to migrate tag {$tag->id} default image from {$oldTagFilename} to {$targetFilename} and/or to set {$targetFilename} as the new tag default image in the settings (DB), Error: " . $e->getMessage());
                 }
+            } else {
+                $this->logger->warning("Old tag default image file {$oldPath} not found.");
             }
         }
 
@@ -135,9 +165,11 @@ class ImageMigrationService
         |--------------------------------------------------------------------------
         */
         echo $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceStep3') . "\n";
+        $this->logger->info("Starting final cleanup of legacy PNG files...");
 
         $this->cleanupLegacyPngs($assetsDir);
 
+        $this->logger->info("Migration process completed. Total migrated images: {$migratedCount}");
         return $migratedCount;
     }
 
@@ -146,22 +178,32 @@ class ImageMigrationService
      */
     protected function cleanupLegacyPngs(string $assetsDir): void
     {
+        $this->logger->info("Cleaning up legacy PNG files from: {$assetsDir}");
+
         $patterns = [
             $assetsDir . DIRECTORY_SEPARATOR . 'card-image-*.png',
             $assetsDir . DIRECTORY_SEPARATOR . 'tag-*-card-image-*.png',
         ];
 
+        $deletedCount = 0;
         foreach ($patterns as $pattern) {
+            $this->logger->debug("Searching for files matching pattern: {$pattern}");
             foreach (glob($pattern) as $file) {
-                $this->safeUnlink($file);
+                $this->logger->debug("Attempting to delete legacy file: " . basename($file));
+                if ($this->safeUnlink($file)) {
+                    $deletedCount++;
+                }
             }
         }
+
+        $this->logger->info("Cleanup completed. Deleted {$deletedCount} legacy files");
     }
 
-    protected function safeUnlink(string $file): void
+    protected function safeUnlink(string $file): bool
     {
         if (!is_file($file)) {
-            return;
+            $this->logger->warning("File not found for deletion: " . basename($file));
+            return false;
         }
 
         $success = @unlink($file);
@@ -171,6 +213,8 @@ class ImageMigrationService
                 'walsgit-discussion-cards.admin.console.imageMigrationServiceCleanupSuccess',
                 ['filename' => basename($file)]
             ) . "\n";
+            $this->logger->info("Successfully deleted file: " . basename($file));
+            return true;
         } else {
             $error = error_get_last();
             $msg = $error['message'] ?? $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceUnknownError');
@@ -179,6 +223,9 @@ class ImageMigrationService
                 'walsgit-discussion-cards.admin.console.imageMigrationServiceCleanupFail',
                 ['filename' => basename($file), 'error' => $msg]
             ) . "\n";
+
+            $this->logger->error("Failed to delete file: " . basename($file) . ", Error: " . $msg);
+            return false;
         }
     }
 }

--- a/src/Services/Migration/ImageMigrationService.php
+++ b/src/Services/Migration/ImageMigrationService.php
@@ -27,6 +27,7 @@ class ImageMigrationService
     protected Connection $db;
     protected $translator;
     protected LoggingService $logger;
+    protected int $failedMigrationCount = 0;
 
     public function __construct(
         Paths $paths,
@@ -56,17 +57,21 @@ class ImageMigrationService
         $public = rtrim($this->paths->public, DIRECTORY_SEPARATOR);
         $assetsDir = $public . DIRECTORY_SEPARATOR . 'assets';
         $migratedCount = 0;
+        $this->failedMigrationCount = 0;
 
         // Log start of migration
-        $this->logger->info("Starting image migration process");
+        $this->logger->info("*** Starting image migration process ***");
+
+        // Validate environment before starting migration
+        $this->validateEnvironment($public);
 
         /*
         |--------------------------------------------------------------------------
         | 1) GENERAL DEFAULT IMAGE MIGRATION (only if a pre v1.4 filename is found in DB)
         |--------------------------------------------------------------------------
         */
-        echo $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceStep1') . "\n";
-        $this->logger->info("Processing general default image migration");
+        echo $this->translator->trans('walsgit_discussion_cards.admin.console.imageMigrationServiceStep1') . "\n";
+        $this->logger->info("Processing general default image migration...");
 
         $oldGeneralFilename = $this->settings->get('walsgit_discussion_cards_default_image_path');
         $this->logger->info("Found general default image in settings: " . ($oldGeneralFilename ?: 'None'));
@@ -78,30 +83,38 @@ class ImageMigrationService
 
             if (is_file($oldPath)) {
                 $targetDir = $public . '/assets/extensions/walsgit-discussion-cards';
-                @mkdir($targetDir, 0775, true);
+                // Use our validation method instead of error suppression
+                if ($this->ensureDirectoryExists($targetDir, 0775)) {
+                    $targetFilename = 'default-card-image.webp';
+                    $targetPath = $targetDir . DIRECTORY_SEPARATOR . $targetFilename;
+                    $this->logger->info("Processing general image: {$oldPath} -> {$targetPath}");
 
-                $targetFilename = 'default-card-image.webp';
-                $targetPath = $targetDir . DIRECTORY_SEPARATOR . $targetFilename;
-                $this->logger->info("Processing general image: {$oldPath} -> {$targetPath}");
+                    try {
+                        $this->imageService->processImage($oldPath, $targetPath);
+                        $this->settings->set(
+                            'walsgit_discussion_cards_default_image_path',
+                            $targetFilename
+                        );
 
-                try {
-                    $this->imageService->processImage($oldPath, $targetPath);
-                    $this->settings->set(
-                        'walsgit_discussion_cards_default_image_path',
-                        $targetFilename
-                    );
-
-                    echo $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceGeneralImageSuccess', ['oldfilename' => $oldGeneralFilename, 'newfilepath' => $targetPath]) . "\n";
-                    $this->logger->info("Successfully migrated general default image: {$oldGeneralFilename} -> {$targetFilename}");
-                    $this->logger->info("Successfully set {$targetFilename} as the new general default image in the settings (DB)");
-                    $migratedCount++;
-                } catch (\Throwable $e) {
-                    echo $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceGeneralImageFail', ['filename' => $oldGeneralFilename]) . $e->getMessage() . "\n";
-                    $this->logger->error("Failed to migrate general default image from {$oldGeneralFilename} to {$targetFilename} and/or to set {$targetFilename} as the new general default image in the settings (DB), Error: " . $e->getMessage());
+                        echo $this->translator->trans('walsgit_discussion_cards.admin.console.imageMigrationServiceGeneralImageSuccess', ['oldfilename' => $oldGeneralFilename, 'newfilepath' => $targetPath]) . "\n";
+                        $this->logger->info("Successfully migrated general default image: {$oldGeneralFilename} -> {$targetFilename}");
+                        $this->logger->info("Successfully set {$targetFilename} as the new general default image in the settings (DB)");
+                        $migratedCount++;
+                    } catch (\Throwable $e) {
+                        echo $this->translator->trans('walsgit_discussion_cards.admin.console.imageMigrationServiceGeneralImageFail', ['filename' => $oldGeneralFilename]) . $e->getMessage() . "\n";
+                        $this->logger->error("Failed to migrate general default image from {$oldGeneralFilename} to {$targetFilename} and/or to set {$targetFilename} as the new general default image in the settings (DB), Error: " . $e->getMessage());
+                        $this->failedMigrationCount++;
+                    }
+                } else {
+                    echo $this->translator->trans('walsgit_discussion_cards.admin.console.imageMigrationServiceGeneralImageFail', ['filename' => $oldGeneralFilename]) . " Failed to create/access target directory.\n";
+                    $this->logger->error("Failed to create/access target directory: {$targetDir}");
+                    $this->failedMigrationCount++;
                 }
             } else {
                 $this->logger->warning("Old general default image file not found: {$oldPath}");
             }
+        } else {
+            $this->logger->info("No migration needed for general default image.");
         }
 
         /*
@@ -109,8 +122,8 @@ class ImageMigrationService
         | 2) TAG DEFAULT IMAGES MIGRATION (only if a pre v1.4 filename is found in DB)
         |--------------------------------------------------------------------------
         */
-        echo $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceStep2') . "\n";
-        $this->logger->info("Processing tag default images migration");
+        echo $this->translator->trans('walsgit_discussion_cards.admin.console.imageMigrationServiceStep2') . "\n";
+        $this->logger->info("Processing tag default images migration...");
 
         $tags = Tag::all();
         $this->logger->info("Found " . $tags->count() . " tags to process");
@@ -134,28 +147,34 @@ class ImageMigrationService
 
             if (is_file($oldPath)) {
                 $targetDir = $public . '/assets/extensions/walsgit-discussion-cards/tags';
-                @mkdir($targetDir, 0775, true);
+                // Use our validation method instead of error suppression
+                if ($this->ensureDirectoryExists($targetDir, 0775)) {
+                    $targetFilename = "tag-{$tag->id}-default-card-image.webp";
+                    $targetPath = $targetDir . DIRECTORY_SEPARATOR . $targetFilename;
+                    $this->logger->info("Processing tag image: {$oldPath} -> {$targetPath}...");
 
-                $targetFilename = "tag-{$tag->id}-default-card-image.webp";
-                $targetPath = $targetDir . DIRECTORY_SEPARATOR . $targetFilename;
-                $this->logger->info("Processing tag image: {$oldPath} -> {$targetPath}...");
+                    try {
+                        $this->imageService->processImage($oldPath, $targetPath);
 
-                try {
-                    $this->imageService->processImage($oldPath, $targetPath);
+                        $tag->walsgit_discussion_cards_tag_default_image = 'tags/' . $targetFilename;
+                        $tag->save();
 
-                    $tag->walsgit_discussion_cards_tag_default_image = 'tags/' . $targetFilename;
-                    $tag->save();
-
-                    echo $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceTagImageSuccess', ['oldfilename' => $oldTagFilename, 'tagid' => $tag->id, 'newfilepath' => $targetPath]) . "\n";
-                    $this->logger->info("Successfully migrated tag {$tag->id} default image: {$oldTagFilename} -> {$targetFilename}");
-                    $this->logger->info("Successfully set {$targetFilename} as the new tag {$tag->id} default image in the tag settings (DB)");
-                    $migratedCount++;
-                } catch (\Throwable $e) {
-                    echo $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceTagImageFail', ['filename' => $oldTagFilename, 'tagid' => $tag->id]) . $e->getMessage() . "\n";
-                    $this->logger->error("Failed to migrate tag {$tag->id} default image from {$oldTagFilename} to {$targetFilename} and/or to set {$targetFilename} as the new tag default image in the settings (DB), Error: " . $e->getMessage());
+                        echo $this->translator->trans('walsgit_discussion_cards.admin.console.imageMigrationServiceTagImageSuccess', ['oldfilename' => $oldTagFilename, 'tagid' => $tag->id, 'newfilepath' => $targetPath]) . "\n";
+                        $this->logger->info("Successfully migrated tag {$tag->id} default image: {$oldTagFilename} -> {$targetFilename}");
+                        $this->logger->info("Successfully set {$targetFilename} as the new tag {$tag->id} default image in the tag settings (DB)");
+                        $migratedCount++;
+                    } catch (\Throwable $e) {
+                        echo $this->translator->trans('walsgit_discussion_cards.admin.console.imageMigrationServiceTagImageFail', ['filename' => $oldTagFilename, 'tagid' => $tag->id]) . $e->getMessage() . "\n";
+                        $this->logger->error("Failed to migrate tag {$tag->id} default image from {$oldTagFilename} to {$targetFilename} and/or to set {$targetFilename} as the new tag default image in the settings (DB), Error: " . $e->getMessage());
+                        $this->failedMigrationCount++;
+                    }
+                } else {
+                    echo $this->translator->trans('walsgit_discussion_cards.admin.console.imageMigrationServiceTagImageFail', ['filename' => $oldTagFilename, 'tagid' => $tag->id]) . " Failed to create/access target directory.\n";
+                    $this->logger->error("Failed to create/access target directory: {$targetDir}");
+                    $this->failedMigrationCount++;
                 }
             } else {
-                $this->logger->warning("Old tag default image file {$oldPath} not found.");
+                $this->logger->warning("Old tag default image file {$oldPath} NOT FOUND.");
             }
         }
 
@@ -164,12 +183,18 @@ class ImageMigrationService
         | 3) FINAL CLEANUP
         |--------------------------------------------------------------------------
         */
-        echo $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceStep3') . "\n";
+        echo $this->translator->trans('walsgit_discussion_cards.admin.console.imageMigrationServiceStep3') . "\n";
         $this->logger->info("Starting final cleanup of legacy PNG files...");
 
-        $this->cleanupLegacyPngs($assetsDir);
+        // Only perform cleanup if no migrations failed
+        if ($this->failedMigrationCount === 0) {
+            $this->cleanupLegacyPngs($assetsDir);
+        } else {
+            $this->logger->info("Skipping cleanup due to {$this->failedMigrationCount} failed migrations");
+            echo $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceNoCleanup', ['failedMigrations' => $this->failedMigrationCount]);
+        }
 
-        $this->logger->info("Migration process completed. Total migrated images: {$migratedCount}");
+        $this->logger->info("Migration process completed. Total migrated images: {$migratedCount}, Failed: {$this->failedMigrationCount}");
         return $migratedCount;
     }
 
@@ -201,31 +226,141 @@ class ImageMigrationService
 
     protected function safeUnlink(string $file): bool
     {
+        // Check if file exists first
+        if (!file_exists($file)) {
+            $this->logger->info("File does not exist (already deleted or never existed): " . basename($file));
+            return true; // Consider as successful since there's nothing to delete
+        }
+
+        // Check if it's actually a file
         if (!is_file($file)) {
-            $this->logger->warning("File not found for deletion: " . basename($file));
+            $this->logger->warning("Path exists but is not a file: " . basename($file));
             return false;
         }
 
+        // Check if file is writable (deletable)
+        if (!is_writable($file)) {
+            $this->logger->error("File exists but is not deletable (permission denied): " . basename($file));
+            echo $this->translator->trans(
+                'walsgit_discussion_cards.admin.console.imageMigrationServiceCleanupFail',
+                ['filename' => basename($file), 'error' => 'Permission denied']
+            ) . "\n";
+            return false;
+        }
+
+        // Attempt to delete the file
         $success = @unlink($file);
 
         if ($success) {
             echo $this->translator->trans(
-                'walsgit-discussion-cards.admin.console.imageMigrationServiceCleanupSuccess',
+                'walsgit_discussion_cards.admin.console.imageMigrationServiceCleanupSuccess',
                 ['filename' => basename($file)]
             ) . "\n";
             $this->logger->info("Successfully deleted file: " . basename($file));
             return true;
         } else {
             $error = error_get_last();
-            $msg = $error['message'] ?? $this->translator->trans('walsgit-discussion-cards.admin.console.imageMigrationServiceUnknownError');
+            $msg = $error['message'] ?? $this->translator->trans('walsgit_discussion_cards.admin.console.imageMigrationServiceUnknownError');
+
+            // Provide more specific error messages
+            if (strpos($msg, 'Permission denied') !== false) {
+                $errorMsg = 'Permission denied';
+            } elseif (strpos($msg, 'No such file or directory') !== false) {
+                $errorMsg = 'File not found';
+            } else {
+                $errorMsg = $msg;
+            }
 
             echo $this->translator->trans(
-                'walsgit-discussion-cards.admin.console.imageMigrationServiceCleanupFail',
-                ['filename' => basename($file), 'error' => $msg]
+                'walsgit_discussion_cards.admin.console.imageMigrationServiceCleanupFail',
+                ['filename' => basename($file), 'error' => $errorMsg]
             ) . "\n";
 
-            $this->logger->error("Failed to delete file: " . basename($file) . ", Error: " . $msg);
+            $this->logger->error("Failed to delete file: " . basename($file) . ", Error: " . $errorMsg);
             return false;
         }
+    }
+
+    /**
+     * Validate environment and required directories before migration.
+     *
+     * @param string $public Public directory path
+     * @throws \RuntimeException If validation fails
+     */
+    protected function validateEnvironment(string $public): void
+    {
+        $this->logger->info("Validating environment for migration...");
+
+        // Check base assets directory
+        $assetsDir = $public . DIRECTORY_SEPARATOR . 'assets';
+        if (!$this->ensureDirectoryExists($assetsDir, 0755)) {
+            $this->logger->error("Cannot access or create assets directory: {$assetsDir}");
+            throw new \RuntimeException("Cannot access or create assets directory: $assetsDir");
+        }
+
+        // Check target directories
+        $targetBaseDir = $public . '/assets/extensions/walsgit-discussion-cards';
+        if (!$this->ensureDirectoryExists($targetBaseDir, 0775)) {
+            $this->logger->error("Cannot create or access target directory: {$targetBaseDir}");
+            throw new \RuntimeException("Cannot create or access target directory: $targetBaseDir");
+        }
+
+        $targetTagsDir = $targetBaseDir . '/tags';
+        if (!$this->ensureDirectoryExists($targetTagsDir, 0775)) {
+            $this->logger->error("Cannot create or access tags directory: {$targetTagsDir}");
+            throw new \RuntimeException("Cannot create or access tags directory: $targetTagsDir");
+        }
+
+        $this->logger->info("Environment validation completed successfully");
+    }
+
+    /**
+     * Ensure directory exists with proper permissions.
+     *
+     * @param string $dir Directory path
+     * @param int $permissions Directory permissions
+     * @return bool True if directory is accessible, false otherwise
+     */
+    protected function ensureDirectoryExists(string $dir, int $permissions): bool
+    {
+        // If directory exists, check if it's writable
+        if (is_dir($dir)) {
+            if (!is_writable($dir)) {
+                $this->logger->error("Directory exists but is not writable: $dir");
+                return false;
+            }
+            $this->logger->debug("Directory already exists and is writable: $dir");
+            return true;
+        }
+
+        // Try to create directory
+        if (!@mkdir($dir, $permissions, true)) {
+            $error = error_get_last();
+            $errorMsg = $error['message'] ?? 'Unknown error';
+
+            // Check if it's a permission issue
+            if (strpos($errorMsg, 'Permission denied') !== false) {
+                $this->logger->error("Permission denied when creating directory: $dir - Error: $errorMsg");
+                return false;
+            }
+
+            // Check if parent directory doesn't exist or is not writable
+            $parentDir = dirname($dir);
+            if (!is_dir($parentDir)) {
+                $this->logger->error("Parent directory does not exist: $parentDir");
+                return false;
+            }
+
+            if (!is_writable($parentDir)) {
+                $this->logger->error("Parent directory is not writable: $parentDir");
+                return false;
+            }
+
+            $this->logger->error("Failed to create directory: $dir - Error: $errorMsg");
+            return false;
+        }
+
+        $this->logger->info("Successfully created directory: $dir with permissions " . decoct($permissions));
+        return true;
     }
 }


### PR DESCRIPTION
### Added
- Logging service to allow creation of logs in `Storage/logs/walsgit-discussion-cards/`.
- The command `php flarum discussion-cards:migrate-images` will now generate more detailed logs in migration-YYYY-mm-dd.log files when executed.
### Changed
- Better checks & validation for the command `php flarum discussion-cards:migrate-images` (do folders exists and have the right permissions, and cleanup shouldn't run if there's any file migration or DB error)
### Fixed
- Some typos.